### PR TITLE
 Allow "python -m" execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .cache/
 *.egg-info/
+__pycache__
+*.pyc
 /build
 /dist

--- a/firefox_cert_override/__main__.py
+++ b/firefox_cert_override/__main__.py
@@ -1,0 +1,9 @@
+"""
+Allow usage like:
+
+    python -m firefox_cert_override --help
+"""
+
+from .cli import generate
+
+generate()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.1.1',
+    version='0.1.2',
 
     description='Tool for generating cert_override.txt for Firefox profiles.',
     long_description=long_description,


### PR DESCRIPTION
Allow firefox-cert-override to be executed like:

    python -m firefox_cert_override [arguments ...]